### PR TITLE
Add Python script to capitalize text file contents

### DIFF
--- a/scripts/capitalize.py
+++ b/scripts/capitalize.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Capitalize all letters in a text file.
+
+Usage:
+    python3 capitalize.py <input_file> [output_file]
+
+If an output_file is provided, the capitalized text is written there.
+Otherwise, the input file is overwritten in place.
+"""
+
+import argparse
+import sys
+
+
+def capitalize_file(input_path: str, output_path: str) -> None:
+    with open(input_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(content.upper())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Capitalize all letters in a text file."
+    )
+    parser.add_argument("input_file", help="Path to the input text file")
+    parser.add_argument(
+        "output_file",
+        nargs="?",
+        default=None,
+        help="Path to write the capitalized text (defaults to overwriting input_file)",
+    )
+    args = parser.parse_args()
+
+    output_path = args.output_file or args.input_file
+
+    try:
+        capitalize_file(args.input_file, output_path)
+    except FileNotFoundError:
+        print(f"Error: file not found: {args.input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Capitalized text written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a standalone Python script, \`scripts/capitalize.py\`, that reads a text file and writes out a version with all letters capitalized.

## Usage
\`\`\`
python3 scripts/capitalize.py <input_file> [output_file]
\`\`\`
- If \`output_file\` is omitted, the input file is overwritten in place.

## Testing
Manually verified locally:
\`\`\`
$ printf "hello world\nthis is a test\n" > input.txt
$ python3 scripts/capitalize.py input.txt output.txt
Capitalized text written to output.txt
$ cat output.txt
HELLO WORLD
THIS IS A TEST
\`\`\`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>