### PR TITLE
Validate room exists before booking (fixes #476)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ example:
 Viewing available rooms can be accessed via `GET localhost:8080/bookings?{date}` where date is in the form `YYYY/MM/DD`.
 
 ## Bugs/Problems
-1. There is a pretty serious bug as users are able to book rooms that don't exist. This is because the app doesn't check if a room exists before making the booking and blindly trusts the client. (realised this a little too late).
+1. ~~There is a pretty serious bug as users are able to book rooms that don't exist. This is because the app doesn't check if a room exists before making the booking and blindly trusts the client. (realised this a little too late).~~ Fixed: the booking service now validates the room exists before creating a booking and returns a 400 error otherwise.
 
 2. I'm missing some validation for when users make a POST request
 

--- a/internal/api/book_room_test.go
+++ b/internal/api/book_room_test.go
@@ -56,6 +56,14 @@ func TestBookRoom(t *testing.T) {
 			expectedResponseBody: `{"error":{"code":500,"message":"Oops, something went wrong"}}`,
 			expectedStatusCode:   http.StatusInternalServerError,
 		},
+		{
+			name:                 "Provide a room that doesn't exist - expect 400 error",
+			userID:               1,
+			requestBody:          `{"date":"2025-01-01","room":"Room 1"}`,
+			mockError:            errors.CustomError{Code: errors.InvalidRoom, Message: "room does not exist"},
+			expectedResponseBody: `{"error":{"code":400,"message":"room does not exist"}}`,
+			expectedStatusCode:   http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/repo/book_room.go
+++ b/internal/repo/book_room.go
@@ -27,3 +27,15 @@ func (b BookRoomRepo) BookRoom(ctx context.Context, room string, user int, date 
 	}
 	return nil
 }
+
+// RoomExists checks whether a room with the given name exists in the rooms table.
+func (b BookRoomRepo) RoomExists(ctx context.Context, room string) (bool, error) {
+	var rooms []string
+	query := `SELECT name FROM rooms WHERE name = ?`
+
+	err := b.Database.Read(ctx, &rooms, query, room)
+	if err != nil {
+		return false, err
+	}
+	return len(rooms) > 0, nil
+}

--- a/internal/repo/book_room_test.go
+++ b/internal/repo/book_room_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBookRoom(t *testing.T) {
@@ -49,6 +51,42 @@ func TestBookRoom(t *testing.T) {
 					t.Errorf("Did not expect error, got: %v", err)
 				}
 			}
+		})
+	}
+}
+
+func TestRoomExists(t *testing.T) {
+	testCases := []struct {
+		name           string
+		room           string
+		expectedExists bool
+	}{
+		{
+			name:           "Room exists",
+			room:           "A",
+			expectedExists: true,
+		},
+		{
+			name:           "Room does not exist",
+			room:           "Nonexistent Room",
+			expectedExists: false,
+		},
+	}
+
+	db, err := testDB()
+	if err != nil {
+		t.Fatalf("unable to connect to DB")
+	}
+	defer db.DB.Close()
+	repo := NewBookRoomsRepo(db)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists, err := repo.RoomExists(context.Background(), tc.room)
+			if err != nil {
+				t.Fatalf("did not expect error, got: %v", err)
+			}
+			assert.Equal(t, tc.expectedExists, exists)
 		})
 	}
 }

--- a/internal/service/book_room.go
+++ b/internal/service/book_room.go
@@ -15,6 +15,7 @@ type BookRoomService struct {
 
 type BookRoomRepo interface {
 	BookRoom(ctx context.Context, room string, user int, date time.Time) error
+	RoomExists(ctx context.Context, room string) (bool, error)
 }
 
 func NewBookRoomService(repo BookRoomRepo) BookRoomService {
@@ -31,8 +32,17 @@ func (b BookRoomService) BookAvailableRoom(ctx context.Context, room string, use
 	if date.Before(today) {
 		return customErr.CustomError{Code: customErr.InvalidDate, Message: "unable to book a date in the past"}
 	}
+
+	exists, err := b.Repo.RoomExists(ctx, room)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return customErr.CustomError{Code: customErr.InvalidRoom, Message: "room does not exist"}
+	}
+
 	var sqlErr sq3.Error
-	err := b.Repo.BookRoom(ctx, room, user, date)
+	err = b.Repo.BookRoom(ctx, room, user, date)
 	if err != nil {
 		if errors.As(err, &sqlErr) && sqlErr.Code == sq3.ErrConstraint {
 			return customErr.CustomError{Code: customErr.RoomAlreadyBooked, Message: "room has already been booked"}

--- a/internal/service/book_room_test.go
+++ b/internal/service/book_room_test.go
@@ -26,15 +26,19 @@ func TestBookAvailableRoom(t *testing.T) {
 		room             string
 		user             int
 		date             time.Time
+		roomExists       bool
+		roomExistsErr    error
 		mockRepoResponse error
 		expectError      bool
 		expectedError    error
+		skipBookRoomMock bool
 	}{
 		{
 			name:             "Successfully book room for a future date",
 			room:             "Room 1",
 			user:             1,
 			date:             time.Date(time.Now().Year()+1, 1, 1, 0, 0, 0, 0, time.UTC),
+			roomExists:       true,
 			mockRepoResponse: nil,
 			expectError:      false,
 		},
@@ -46,15 +50,27 @@ func TestBookAvailableRoom(t *testing.T) {
 			mockRepoResponse: nil,
 			expectError:      true,
 			expectedError:    customErr.CustomError{Code: customErr.InvalidDate, Message: "unable to book a date in the past"},
+			skipBookRoomMock: true,
 		},
 		{
 			name:             "Book room that's already booked, expect room already booked error",
 			room:             "Room 1",
 			user:             1,
 			date:             time.Date(time.Now().Year()+1, 1, 1, 0, 0, 0, 0, time.UTC),
+			roomExists:       true,
 			mockRepoResponse: sqlite3.Error{Code: sqlite3.ErrConstraint},
 			expectError:      true,
 			expectedError:    customErr.CustomError{Code: customErr.RoomAlreadyBooked, Message: "room has already been booked"},
+		},
+		{
+			name:             "Book a room that doesn't exist, expect invalid room error",
+			room:             "Nonexistent Room",
+			user:             1,
+			date:             time.Date(time.Now().Year()+1, 1, 1, 0, 0, 0, 0, time.UTC),
+			roomExists:       false,
+			expectError:      true,
+			expectedError:    customErr.CustomError{Code: customErr.InvalidRoom, Message: "room does not exist"},
+			skipBookRoomMock: true,
 		},
 	}
 
@@ -62,7 +78,10 @@ func TestBookAvailableRoom(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockRepo := mocks.NewBookRoomRepo(t)
 
-			mockRepo.On("BookRoom", mock.Anything, tc.room, tc.user, tc.date).Maybe().Return(tc.mockRepoResponse)
+			mockRepo.On("RoomExists", mock.Anything, tc.room).Maybe().Return(tc.roomExists, tc.roomExistsErr)
+			if !tc.skipBookRoomMock {
+				mockRepo.On("BookRoom", mock.Anything, tc.room, tc.user, tc.date).Maybe().Return(tc.mockRepoResponse)
+			}
 
 			service := NewBookRoomService(mockRepo)
 

--- a/internal/service/mocks/BookRoomRepo.go
+++ b/internal/service/mocks/BookRoomRepo.go
@@ -29,6 +29,27 @@ func (_m *BookRoomRepo) BookRoom(ctx context.Context, room string, user int, dat
 	return r0
 }
 
+// RoomExists provides a mock function with given fields: ctx, room
+func (_m *BookRoomRepo) RoomExists(ctx context.Context, room string) (bool, error) {
+	ret := _m.Called(ctx, room)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, room)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, room)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewBookRoomRepo interface {
 	mock.TestingT
 	Cleanup(func())


### PR DESCRIPTION
## Summary
Fixes #476 — the app previously let users book rooms that don't exist because it blindly trusted the client-provided `room` name with no server-side validation.

## Changes
- Added `BookRoomRepo.RoomExists(ctx, room)` in `internal/repo/book_room.go` to check the `rooms` table.
- `BookRoomService.BookAvailableRoom` now checks room existence before attempting to book, returning the existing (previously unused!) `errors.InvalidRoom` custom error — which the API layer already maps to a `400 Bad Request` with a clear message.
- Extended tests at the repo (`TestRoomExists`), service (`TestBookAvailableRoom`), and API (`TestBookRoom`) layers to cover the new behavior.
- Updated README's known-bugs section to mark this as fixed.

## Testing
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass